### PR TITLE
Make sure SQLite accept both int and integer as pk

### DIFF
--- a/translators/sqlite.go
+++ b/translators/sqlite.go
@@ -35,7 +35,7 @@ func (p *SQLite) CreateTable(t fizz.Table) (string, error) {
 	for _, c := range t.Columns {
 		if c.Primary {
 			switch strings.ToLower(c.ColType) {
-			case "integer":
+			case "integer", "int":
 				s = fmt.Sprintf("\"%s\" INTEGER PRIMARY KEY AUTOINCREMENT", c.Name)
 			case "uuid", "string":
 				s = fmt.Sprintf("\"%s\" TEXT PRIMARY KEY", c.Name)


### PR DESCRIPTION
This is the behavior for the others drivers, there is no reason to
discriminate SQLite.