### PR TITLE
switch to timezone aware timestamps

### DIFF
--- a/translators/postgres.go
+++ b/translators/postgres.go
@@ -217,7 +217,7 @@ func (p *Postgres) colType(c fizz.Column) string {
 	case "uuid":
 		return "UUID"
 	case "time", "datetime":
-		return "timestamp"
+		return "timestamptz"
 	case "blob", "[]byte":
 		return "bytea"
 	case "float", "decimal":


### PR DESCRIPTION
Best practice with postgres is to use timestamps with timezone handling.
This is done by using timestamptz instead of timestamp as the column
type.

With timestamp there is no understanding of timezones and so
applications need to do all the timezone handling themselves including
being consistent in what timezone they work with from release to
release.

With timestamptz postgres will convert any timestamp that comes in to be
in UTC format and then will convert that back to the session's timezone
when read back.