### PR TITLE
AFile uses io.Reader

### DIFF
--- a/fizz.go
+++ b/fizz.go
@@ -46,8 +46,8 @@ func (f fizzer) Exec(out io.Writer) func(string) error {
 	}
 }
 
-// AFile reads a fizz file, and translates its contents to SQL.
-func AFile(f *os.File, t Translator) (string, error) {
+// AFile reads in a fizz migration from an io.Reader and translates its contents to SQL.
+func AFile(f io.Reader, t Translator) (string, error) {
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
 		return "", errors.WithStack(err)


### PR DESCRIPTION
This small PR simply switches `AFile` to use an `io.Reader` rather than an `os.File`.  This streamlines integration with our sources of migration files, such as AWS S3.  `os.File` implements `io.Reader`, so should have no impact on existing users.