### PR TITLE
DisableExec flag

### DIFF
--- a/bubbler.go
+++ b/bubbler.go
@@ -11,13 +11,23 @@ type BubbleType int
 
 type Bubbler struct {
 	Translator
-	data []string
+	data        []string
+	DisableExec bool
 }
 
 func NewBubbler(t Translator) *Bubbler {
 	return &Bubbler{
-		Translator: t,
-		data:       []string{},
+		Translator:  t,
+		data:        []string{},
+		DisableExec: false,
+	}
+}
+
+func NewBubblerWithDisabledExec(t Translator) *Bubbler {
+	return &Bubbler{
+		Translator:  t,
+		data:        []string{},
+		DisableExec: true,
 	}
 }
 
@@ -26,7 +36,10 @@ func (b *Bubbler) String() string {
 }
 
 func (b *Bubbler) Bubble(s string) (string, error) {
-	f := fizzer{b}
+	f := fizzer{
+		Bubbler:     b,
+		DisableExec: b.DisableExec,
+	}
 	ctx := plush.NewContextWith(map[string]interface{}{
 		"exec":             f.Exec(os.Stdout),
 		"create_table":     f.CreateTable,

--- a/bubbler_test.go
+++ b/bubbler_test.go
@@ -12,7 +12,7 @@ func Test_Exec(t *testing.T) {
 	r := require.New(t)
 
 	b := NewBubbler(nil)
-	f := fizzer{b}
+	f := fizzer{Bubbler: b, DisableExec: false}
 	bb := &bytes.Buffer{}
 	c := f.Exec(bb)
 	c("echo hello")
@@ -23,7 +23,7 @@ func Test_ExecQuoted(t *testing.T) {
 	r := require.New(t)
 
 	b := NewBubbler(nil)
-	f := fizzer{b}
+	f := fizzer{Bubbler: b, DisableExec: false}
 	bb := &bytes.Buffer{}
 	c := f.Exec(bb)
 	// without proper splitting we would get "'a b c'"

--- a/fizz.go
+++ b/fizz.go
@@ -17,7 +17,8 @@ import (
 type Options map[string]interface{}
 
 type fizzer struct {
-	Bubbler *Bubbler
+	Bubbler     *Bubbler
+	DisableExec bool
 }
 
 func (f fizzer) add(s string, err error) error {
@@ -29,6 +30,11 @@ func (f fizzer) add(s string, err error) error {
 }
 
 func (f fizzer) Exec(out io.Writer) func(string) error {
+	if f.DisableExec {
+		return func(s string) error {
+			return nil
+		}
+	}
 	return func(s string) error {
 		args, err := shellquote.Split(s)
 		if err != nil {


### PR DESCRIPTION
The `DisableExec` can be used to disable execution of `exec("....")` within fizz files, such as during syntax validation.  This is simple approach and preferable to a regex replace approach.

Default behavior is preserved and the only new public function is `NewBubblerWithDisabledExec`.