### PR TITLE
added support of exact numeric data values

### DIFF
--- a/translators/mysql.go
+++ b/translators/mysql.go
@@ -246,17 +246,18 @@ func (p *MySQL) colType(c fizz.Column) string {
 		return "BLOB"
 	case "int", "integer":
 		return "INTEGER"
-	case "float", "decimal":
+	case "float", "double", "decimal", "numeric":
+		colType := strings.ToUpper(c.ColType)
 		if c.Options["precision"] != nil {
 			precision := c.Options["precision"]
 			if c.Options["scale"] != nil {
 				scale := c.Options["scale"]
-				return fmt.Sprintf("FLOAT(%d,%d)", precision, scale)
+				return fmt.Sprintf("%s(%d,%d)",colType, precision, scale)
 			}
-			return fmt.Sprintf("FLOAT(%d)", precision)
+			return fmt.Sprintf("%s(%d)",colType, precision)
 		}
 
-		return "FLOAT"
+		return colType
 	case "json":
 		return "JSON"
 	default:

--- a/translators/mysql.go
+++ b/translators/mysql.go
@@ -252,9 +252,9 @@ func (p *MySQL) colType(c fizz.Column) string {
 			precision := c.Options["precision"]
 			if c.Options["scale"] != nil {
 				scale := c.Options["scale"]
-				return fmt.Sprintf("%s(%d,%d)",colType, precision, scale)
+				return fmt.Sprintf("%s(%d,%d)", colType, precision, scale)
 			}
-			return fmt.Sprintf("%s(%d)",colType, precision)
+			return fmt.Sprintf("%s(%d)", colType, precision)
 		}
 
 		return colType

--- a/translators/mysql_test.go
+++ b/translators/mysql_test.go
@@ -49,7 +49,12 @@ PRIMARY KEY(` + "`id`" + `),
 ` + "`age`" + ` INTEGER DEFAULT 40,
 ` + "`raw`" + ` BLOB NOT NULL,
 ` + "`json`" + ` JSON NOT NULL,
-` + "`float`" + ` FLOAT(5) NOT NULL,
+` + "`float`" + ` FLOAT NOT NULL,
+` + "`float_noscale`" + ` FLOAT(5) NOT NULL,
+` + "`float_scale`" + ` FLOAT(5,2) NOT NULL,
+` + "`decimal`" + ` DECIMAL(6,2) NOT NULL,
+` + "`numeric`" + ` NUMERIC(7,2) NOT NULL,
+` + "`double`" + ` DOUBLE(8,2) NOT NULL,
 ` + "`integer`" + ` INTEGER NOT NULL,
 ` + "`bytes`" + ` BLOB NOT NULL,
 ` + "`created_at`" + ` DATETIME NOT NULL,
@@ -66,7 +71,12 @@ PRIMARY KEY(` + "`id`" + `),
 		t.Column("age", "integer", {"null": true, "default": 40})
 		t.Column("raw", "blob", {})
 		t.Column("json", "json", {})
-		t.Column("float", "float", {"precision": 5})
+		t.Column("float", "float")
+		t.Column("float_noscale", "float", {"precision": 5})
+		t.Column("float_scale", "float", {"precision": 5,"scale":2})
+		t.Column("decimal", "decimal", {"precision": 6,"scale":2})
+		t.Column("numeric", "numeric", {"precision": 7,"scale":2})
+		t.Column("double", "double", {"precision": 8,"scale":2})
 		t.Column("integer", "integer", {})
 		t.Column("bytes", "[]byte", {})
 	}


### PR DESCRIPTION
[floating point types](https://dev.mysql.com/doc/refman/5.7/en/floating-point-types.html) (float, double) and [fixed point types](https://dev.mysql.com/doc/refman/5.7/en/fixed-point-types.html) (numeric, decimal) are different in mysql. changed translator to support other non mentioned types and return what we type in .fizz instead of returning FLOAT everytime. 