### PR TITLE
Fix timestamps macro generation conditions

### DIFF
--- a/columns.go
+++ b/columns.go
@@ -23,8 +23,8 @@ var UUID_ID_COL = Column{
 	Options: Options{},
 }
 
-var CREATED_COL = Column{Name: "created_at", ColType: "timestamp", Options: Options{}}
-var UPDATED_COL = Column{Name: "updated_at", ColType: "timestamp", Options: Options{}}
+var CREATED_COL = Column{Name: "created_at", ColType: "timestamp", Options: nil}
+var UPDATED_COL = Column{Name: "updated_at", ColType: "timestamp", Options: nil}
 
 type Column struct {
 	Name    string

--- a/tables_test.go
+++ b/tables_test.go
@@ -76,6 +76,43 @@ func Test_Table_StringerOpts(t *testing.T) {
 	r.Equal(expected, table.String())
 }
 
+func Test_Table_StringerAutoDisableTimestamps(t *testing.T) {
+	r := require.New(t)
+
+	// Custom type timestamps
+	expected :=
+		`create_table("users") {
+	t.Column("name", "string")
+	t.Column("created_at", "int")
+	t.Column("updated_at", "int")
+}`
+
+	table := fizz.NewTable("users", map[string]interface{}{
+		"timestamps": true,
+	})
+	r.NoError(table.Column("name", "string", nil))
+	r.NoError(table.Column("created_at", "int", nil))
+	r.NoError(table.Column("updated_at", "int", nil))
+
+	r.Equal(expected, table.String())
+
+	// only one timestamp override
+	expected =
+		`create_table("users") {
+	t.Column("name", "string")
+	t.Column("created_at", "int")
+	t.Column("updated_at", "timestamp")
+}`
+
+	table = fizz.NewTable("users", map[string]interface{}{
+		"timestamps": true,
+	})
+	r.NoError(table.Column("name", "string", nil))
+	r.NoError(table.Column("created_at", "int", nil))
+
+	r.Equal(expected, table.String())
+}
+
 func Test_Table_StringerIndex(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
Make sure to honor timestamps option even when one of created_at and
updated_at are provided with a custom type.