### PR TITLE
Support constraint actions in CockroachDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,13 @@ go 1.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/fatih/structs v1.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gobuffalo/helpers v0.2.4 // indirect
 	github.com/gobuffalo/packr/v2 v2.5.3
 	github.com/gobuffalo/plush v3.8.3+incompatible
-	github.com/gobuffalo/uuid v2.0.5+incompatible // indirect
-	github.com/gobuffalo/validate v2.0.3+incompatible // indirect
-	github.com/gofrs/uuid v3.2.0+incompatible // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/onsi/ginkgo v1.9.0 // indirect
 	github.com/onsi/gomega v1.6.0 // indirect
-	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516 // indirect
 	github.com/stretchr/testify v1.4.0
 	google.golang.org/appengine v1.6.1 // indirect
 )

--- a/packrd/packed-packr.go
+++ b/packrd/packed-packr.go
@@ -24,7 +24,7 @@ var _ = func() error {
 	func() {
 		b := packr.New("github.com/gobuffalo/helpers/genny/docs/templates", "../docs/templates")
 		b.SetResolver("README.md.plush", packr.Pointer{ForwardBox: gk, ForwardPath: "219f70cdf30f6f12b6c726d0cb3c36b8"})
-		}()
+	}()
 
 	return nil
 }()

--- a/translators/cockroach.go
+++ b/translators/cockroach.go
@@ -412,6 +412,14 @@ func (p *Cockroach) buildForeignKey(t fizz.Table, fk fizz.ForeignKey, onCreate b
 	refs := fmt.Sprintf("%s (%s)", p.escapeIdentifier(fk.References.Table), strings.Join(rcols, ", "))
 	s := fmt.Sprintf("CONSTRAINT \"%s\" FOREIGN KEY (\"%s\") REFERENCES %s", fk.Name, fk.Column, refs)
 
+	if onUpdate, ok := fk.Options["on_update"]; ok {
+		s += fmt.Sprintf(" ON UPDATE %s", onUpdate)
+	}
+
+	if onDelete, ok := fk.Options["on_delete"]; ok {
+		s += fmt.Sprintf(" ON DELETE %s", onDelete)
+	}
+
 	if !onCreate {
 		s = fmt.Sprintf("ALTER TABLE %s ADD %s;COMMIT TRANSACTION;BEGIN TRANSACTION;", p.escapeIdentifier(t.Name), s)
 	}

--- a/translators/cockroach_test.go
+++ b/translators/cockroach_test.go
@@ -21,7 +21,7 @@ func (p *CockroachSuite) crdbt() *translators.Cockroach {
 	ta.Column("mycolumn", "type", nil)
 	schema["mytable"] = ta
 	ta = &fizz.Table{Name: "table"}
-	ta.Indexes = []fizz.Index{fizz.Index{Name: "old_ix"}}
+	ta.Indexes = []fizz.Index{{Name: "old_ix"}}
 	schema["table"] = ta
 	ta = &fizz.Table{Name: "profiles"}
 	schema["profiles"] = ta
@@ -107,7 +107,7 @@ PRIMARY KEY("id"),
 "last_name" VARCHAR (255) NOT NULL,
 "created_at" timestamp NOT NULL,
 "updated_at" timestamp NOT NULL,
-CONSTRAINT "profiles_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+CONSTRAINT "profiles_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON UPDATE CASCADE ON DELETE SET NULL
 );COMMIT TRANSACTION;BEGIN TRANSACTION;`
 
 	res, _ := fizz.AString(`
@@ -120,7 +120,7 @@ CONSTRAINT "profiles_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users" ("i
 		t.Column("user_id", "INT", {})
 		t.Column("first_name", "string", {})
 		t.Column("last_name", "string", {})
-		t.ForeignKey("user_id", {"users": ["id"]}, {})
+		t.ForeignKey("user_id", {"users": ["id"]}, {"on_delete": "SET NULL", "on_update":"CASCADE"})
 	}
 	`, p.crdbt())
 	r.Equal(ddl, res)

--- a/translators/sqlite_test.go
+++ b/translators/sqlite_test.go
@@ -261,7 +261,7 @@ func (p *SQLiteSuite) Test_SQLite_AddIndex() {
 	schema.schema["table_name"] = &fizz.Table{
 		Name: "table_name",
 		Columns: []fizz.Column{
-			fizz.Column{
+			{
 				Name: "column_name",
 			},
 		},
@@ -303,7 +303,7 @@ func (p *SQLiteSuite) Test_SQLite_DropIndex() {
 	schema.schema["my_table"] = &fizz.Table{
 		Name: "my_table",
 		Indexes: []fizz.Index{
-			fizz.Index{
+			{
 				Name: "my_idx",
 			},
 		},


### PR DESCRIPTION
CockroachDB supports `ON DELETE|CASCADE` since version 2.0 (released
April 2018).

This patch adds `ON DELETE` and `ON CASCADE` translation for cdb.