### PR TITLE
Move away from cockroach v1 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,13 @@ services:
     image: postgres:9.6
     environment:
       - POSTGRES_DB=pop_test
+      - POSTGRES_PASSWORD=postgres
     ports:
       - "5432:5432"
     volumes:
       - ./sqldumps:/docker-entrypoint-initdb.d
   cockroach:
-    image: cockroachdb/cockroach:v1.1.1
+    image: cockroachdb/cockroach:v2.1.0
     ports:
       - "26257:26257"
       - "8080:8080"

--- a/translators/cockroach_meta.go
+++ b/translators/cockroach_meta.go
@@ -118,7 +118,7 @@ func (p *cockroachSchema) buildTableData(table *fizz.Table, db *sql.DB) error {
 }
 
 func (p *cockroachSchema) buildTableIndexes(t *fizz.Table, db *sql.DB) error {
-	prag := fmt.Sprintf("SELECT distinct index_name as name, non_unique FROM information_schema.statistics where table_name = '%s';", t.Name)
+	prag := fmt.Sprintf("SELECT distinct index_name as name, (non_unique = 'YES') as non_unique FROM information_schema.statistics where table_name = '%s';", t.Name)
 	res, err := db.Query(prag)
 	if err != nil {
 		return err


### PR DESCRIPTION
Assuming we want to drop Cockroach v1, as discussed in #84, this PR will get us back up and running in v2 and later.

What was done:
*Move away from cockroach v1 support
*fixed local tests after postgres change and removal of cockroach v1 support