### PR TITLE
Respect foreign keys on CockroachDB change_column

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ make test
 ```
 
 If you made changes to the end-to-end tests and want to update the fixtures,
-run:
+run the following command a couple of times until tests pass:
 
 ```
 REFRESH_FIXTURES=true make test

--- a/internal/e2e/fixtures/cockroach/down/1.sql
+++ b/internal/e2e/fixtures/cockroach/down/1.sql
@@ -1,3 +1,12 @@
+CREATE TABLE e2e_users (
+	id UUID NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	username VARCHAR(255) NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, created_at, updated_at, username)
+);
+
 CREATE TABLE schema_migration (
 	version VARCHAR(14) NOT NULL,
 	UNIQUE INDEX schema_migration_version_idx (version ASC),

--- a/internal/e2e/fixtures/cockroach/down/1.sql
+++ b/internal/e2e/fixtures/cockroach/down/1.sql
@@ -1,12 +1,3 @@
-CREATE TABLE e2e_users (
-	id UUID NOT NULL,
-	created_at TIMESTAMP NOT NULL,
-	updated_at TIMESTAMP NOT NULL,
-	username VARCHAR(255) NULL,
-	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	FAMILY "primary" (id, created_at, updated_at, username)
-);
-
 CREATE TABLE schema_migration (
 	version VARCHAR(14) NOT NULL,
 	UNIQUE INDEX schema_migration_version_idx (version ASC),

--- a/internal/e2e/fixtures/cockroach/down/10.sql
+++ b/internal/e2e/fixtures/cockroach/down/10.sql
@@ -2,22 +2,19 @@ CREATE TABLE e2e_users (
 	id UUID NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL,
-	name VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	FAMILY "primary" (id, created_at, updated_at, name)
+	FAMILY "primary" (id, created_at, updated_at)
 );
 
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
-	user_id UUID NOT NULL,
 	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
-	published BOOL NOT NULL DEFAULT false,
+	user_id UUID NOT NULL,
 	slug VARCHAR(64) NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, content, published, slug)
+	FAMILY "primary" (id, content, user_id, slug)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/10.sql
+++ b/internal/e2e/fixtures/cockroach/down/10.sql
@@ -2,20 +2,22 @@ CREATE TABLE e2e_users (
 	id UUID NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL,
+	name VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	FAMILY "primary" (id, created_at, updated_at)
+	FAMILY "primary" (id, created_at, updated_at, name)
 );
 
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
 	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
+	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, content, slug)
+	FAMILY "primary" (id, user_id, content, published, slug)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/11.sql
+++ b/internal/e2e/fixtures/cockroach/down/11.sql
@@ -1,0 +1,29 @@
+CREATE TABLE e2e_users (
+	id UUID NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, created_at, updated_at)
+);
+
+CREATE TABLE e2e_user_posts (
+	id UUID NOT NULL,
+	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
+	slug VARCHAR(32) NOT NULL,
+	user_id UUID NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
+	INDEX e2e_user_notes_user_id_idx (user_id ASC),
+	FAMILY "primary" (id, content, slug, user_id)
+);
+
+CREATE TABLE schema_migration (
+	version VARCHAR(14) NOT NULL,
+	UNIQUE INDEX schema_migration_version_idx (version ASC),
+	FAMILY "primary" (version, rowid)
+);
+
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/12.sql
+++ b/internal/e2e/fixtures/cockroach/down/12.sql
@@ -1,0 +1,29 @@
+CREATE TABLE e2e_authors (
+	id UUID NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, created_at, updated_at)
+);
+
+CREATE TABLE e2e_user_posts (
+	id UUID NOT NULL,
+	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
+	slug VARCHAR(32) NOT NULL,
+	user_id UUID NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
+	INDEX e2e_user_notes_user_id_idx (user_id ASC),
+	FAMILY "primary" (id, content, slug, user_id)
+);
+
+CREATE TABLE schema_migration (
+	version VARCHAR(14) NOT NULL,
+	UNIQUE INDEX schema_migration_version_idx (version ASC),
+	FAMILY "primary" (version, rowid)
+);
+
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_authors(id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/13.sql
+++ b/internal/e2e/fixtures/cockroach/down/13.sql
@@ -1,0 +1,29 @@
+CREATE TABLE e2e_authors (
+	id UUID NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, created_at, updated_at)
+);
+
+CREATE TABLE e2e_user_posts (
+	id UUID NOT NULL,
+	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
+	slug VARCHAR(32) NOT NULL,
+	author_id UUID NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
+	INDEX e2e_user_notes_user_id_idx (author_id ASC),
+	FAMILY "primary" (id, content, slug, author_id)
+);
+
+CREATE TABLE schema_migration (
+	version VARCHAR(14) NOT NULL,
+	UNIQUE INDEX schema_migration_version_idx (version ASC),
+	FAMILY "primary" (version, rowid)
+);
+
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (author_id) REFERENCES e2e_authors(id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/2.sql
+++ b/internal/e2e/fixtures/cockroach/down/2.sql
@@ -7,25 +7,8 @@ CREATE TABLE e2e_users (
 	FAMILY "primary" (id, created_at, updated_at, username)
 );
 
-CREATE TABLE e2e_user_notes (
-	id UUID NOT NULL,
-	user_id UUID NOT NULL,
-	notes VARCHAR(255) NULL,
-	title VARCHAR(64) NOT NULL DEFAULT '':::STRING,
-	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
-	INDEX e2e_user_notes_user_id_idx (user_id ASC),
-	INDEX e2e_user_notes_title_idx (title ASC),
-	FAMILY "primary" (id, user_id, notes, title)
-);
-
 CREATE TABLE schema_migration (
 	version VARCHAR(14) NOT NULL,
 	UNIQUE INDEX schema_migration_version_idx (version ASC),
 	FAMILY "primary" (version, rowid)
 );
-
-ALTER TABLE e2e_user_notes ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
-
--- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
-ALTER TABLE e2e_user_notes VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/2.sql
+++ b/internal/e2e/fixtures/cockroach/down/2.sql
@@ -7,8 +7,24 @@ CREATE TABLE e2e_users (
 	FAMILY "primary" (id, created_at, updated_at, username)
 );
 
+CREATE TABLE e2e_user_notes (
+	id UUID NOT NULL,
+	user_id UUID NOT NULL,
+	notes VARCHAR(255) NULL,
+	title VARCHAR(64) NOT NULL DEFAULT '':::STRING,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX e2e_user_notes_user_id_idx (user_id ASC),
+	INDEX e2e_user_notes_title_idx (title ASC),
+	FAMILY "primary" (id, user_id, notes, title)
+);
+
 CREATE TABLE schema_migration (
 	version VARCHAR(14) NOT NULL,
 	UNIQUE INDEX schema_migration_version_idx (version ASC),
 	FAMILY "primary" (version, rowid)
 );
+
+ALTER TABLE e2e_user_notes ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE e2e_user_notes VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/3.sql
+++ b/internal/e2e/fixtures/cockroach/down/3.sql
@@ -10,14 +10,10 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	published BOOL NOT NULL DEFAULT false,
 	notes VARCHAR(255) NULL,
-	title VARCHAR(64) NOT NULL DEFAULT '':::STRING,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
-	INDEX e2e_user_notes_title_idx (title ASC),
-	FAMILY "primary" (id, user_id, published, notes, title)
+	FAMILY "primary" (id, user_id, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/3.sql
+++ b/internal/e2e/fixtures/cockroach/down/3.sql
@@ -10,11 +10,14 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
+	published BOOL NOT NULL DEFAULT false,
 	notes VARCHAR(255) NULL,
+	title VARCHAR(64) NOT NULL DEFAULT '':::STRING,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
-	FAMILY "primary" (id, user_id, notes)
+	INDEX e2e_user_notes_title_idx (title ASC),
+	FAMILY "primary" (id, user_id, published, notes, title)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/4.sql
+++ b/internal/e2e/fixtures/cockroach/down/4.sql
@@ -10,13 +10,12 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	slug VARCHAR(64) NOT NULL,
+	published BOOL NOT NULL DEFAULT false,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
-	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, slug, notes)
+	FAMILY "primary" (id, user_id, published, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/4.sql
+++ b/internal/e2e/fixtures/cockroach/down/4.sql
@@ -10,12 +10,12 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	published BOOL NOT NULL DEFAULT false,
+	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
-	FAMILY "primary" (id, user_id, published, notes)
+	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
+	FAMILY "primary" (id, user_id, slug, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/5.sql
+++ b/internal/e2e/fixtures/cockroach/down/5.sql
@@ -10,13 +10,14 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
+	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, slug, notes)
+	FAMILY "primary" (id, user_id, published, slug, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/5.sql
+++ b/internal/e2e/fixtures/cockroach/down/5.sql
@@ -10,14 +10,12 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, published, slug, notes)
+	FAMILY "primary" (id, user_id, slug, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/6.sql
+++ b/internal/e2e/fixtures/cockroach/down/6.sql
@@ -10,13 +10,14 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
+	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, slug, notes)
+	FAMILY "primary" (id, user_id, published, slug, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/6.sql
+++ b/internal/e2e/fixtures/cockroach/down/6.sql
@@ -10,14 +10,12 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, published, slug, notes)
+	FAMILY "primary" (id, user_id, slug, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/7.sql
+++ b/internal/e2e/fixtures/cockroach/down/7.sql
@@ -7,16 +7,17 @@ CREATE TABLE e2e_users (
 	FAMILY "primary" (id, created_at, updated_at, username)
 );
 
-CREATE TABLE e2e_user_posts (
+CREATE TABLE e2e_user_notes (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
+	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, slug, notes)
+	FAMILY "primary" (id, user_id, published, slug, notes)
 );
 
 CREATE TABLE schema_migration (
@@ -25,7 +26,7 @@ CREATE TABLE schema_migration (
 	FAMILY "primary" (version, rowid)
 );
 
-ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
+ALTER TABLE e2e_user_notes ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
 
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
-ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;
+ALTER TABLE e2e_user_notes VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/7.sql
+++ b/internal/e2e/fixtures/cockroach/down/7.sql
@@ -7,17 +7,15 @@ CREATE TABLE e2e_users (
 	FAMILY "primary" (id, created_at, updated_at, username)
 );
 
-CREATE TABLE e2e_user_notes (
+CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
 	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, published, slug, notes)
+	FAMILY "primary" (id, user_id, slug, notes)
 );
 
 CREATE TABLE schema_migration (
@@ -26,7 +24,7 @@ CREATE TABLE schema_migration (
 	FAMILY "primary" (version, rowid)
 );
 
-ALTER TABLE e2e_user_notes ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
 
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
-ALTER TABLE e2e_user_notes VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;
+ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/down/8.sql
+++ b/internal/e2e/fixtures/cockroach/down/8.sql
@@ -10,13 +10,14 @@ CREATE TABLE e2e_users (
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
-	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
+	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
+	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, content, slug)
+	FAMILY "primary" (id, user_id, published, slug, notes)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/8.sql
+++ b/internal/e2e/fixtures/cockroach/down/8.sql
@@ -9,15 +9,13 @@ CREATE TABLE e2e_users (
 
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
+	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
 	user_id UUID NOT NULL,
-	published BOOL NOT NULL DEFAULT false,
 	slug VARCHAR(64) NOT NULL,
-	notes VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, published, slug, notes)
+	FAMILY "primary" (id, content, user_id, slug)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/down/9.sql
+++ b/internal/e2e/fixtures/cockroach/down/9.sql
@@ -2,22 +2,20 @@ CREATE TABLE e2e_users (
 	id UUID NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL,
-	username VARCHAR(255) NULL,
+	name VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	FAMILY "primary" (id, created_at, updated_at, username)
+	FAMILY "primary" (id, created_at, updated_at, name)
 );
 
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
-	user_id UUID NOT NULL,
 	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
-	published BOOL NOT NULL DEFAULT false,
+	user_id UUID NOT NULL,
 	slug VARCHAR(64) NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, content, published, slug)
+	FAMILY "primary" (id, content, user_id, slug)
 );
 
 CREATE TABLE schema_migration (

--- a/internal/e2e/fixtures/cockroach/up/11.sql
+++ b/internal/e2e/fixtures/cockroach/up/11.sql
@@ -1,23 +1,21 @@
-CREATE TABLE e2e_users (
+CREATE TABLE e2e_authors (
 	id UUID NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL,
-	username VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	FAMILY "primary" (id, created_at, updated_at, username)
+	FAMILY "primary" (id, created_at, updated_at)
 );
 
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
 	user_id UUID NOT NULL,
 	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
-	published BOOL NOT NULL DEFAULT false,
-	slug VARCHAR(64) NOT NULL,
+	slug VARCHAR(32) NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
 	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
 	INDEX e2e_user_notes_user_id_idx (user_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, content, published, slug)
+	FAMILY "primary" (id, user_id, content, slug)
 );
 
 CREATE TABLE schema_migration (
@@ -26,7 +24,7 @@ CREATE TABLE schema_migration (
 	FAMILY "primary" (version, rowid)
 );
 
-ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_authors(id) ON DELETE CASCADE;
 
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
 ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/up/12.sql
+++ b/internal/e2e/fixtures/cockroach/up/12.sql
@@ -1,23 +1,21 @@
-CREATE TABLE e2e_users (
+CREATE TABLE e2e_authors (
 	id UUID NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL,
-	username VARCHAR(255) NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	FAMILY "primary" (id, created_at, updated_at, username)
+	FAMILY "primary" (id, created_at, updated_at)
 );
 
 CREATE TABLE e2e_user_posts (
 	id UUID NOT NULL,
-	user_id UUID NOT NULL,
+	author_id UUID NOT NULL,
 	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
-	published BOOL NOT NULL DEFAULT false,
-	slug VARCHAR(64) NOT NULL,
+	slug VARCHAR(32) NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (user_id ASC),
-	INDEX e2e_user_notes_user_id_idx (user_id ASC),
+	INDEX e2e_user_notes_auto_index_e2e_user_notes_e2e_users_id_fk (author_id ASC),
+	INDEX e2e_user_notes_user_id_idx (author_id ASC),
 	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
-	FAMILY "primary" (id, user_id, content, published, slug)
+	FAMILY "primary" (id, author_id, content, slug)
 );
 
 CREATE TABLE schema_migration (
@@ -26,7 +24,7 @@ CREATE TABLE schema_migration (
 	FAMILY "primary" (version, rowid)
 );
 
-ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (user_id) REFERENCES e2e_users(id) ON DELETE CASCADE;
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (author_id) REFERENCES e2e_authors(id) ON DELETE CASCADE;
 
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
 ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/cockroach/up/13.sql
+++ b/internal/e2e/fixtures/cockroach/up/13.sql
@@ -1,0 +1,30 @@
+CREATE TABLE e2e_authors (
+	id UUID NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, created_at, updated_at)
+);
+
+CREATE TABLE e2e_user_posts (
+	id UUID NOT NULL,
+	content VARCHAR(255) NOT NULL DEFAULT '':::STRING,
+	slug VARCHAR(32) NOT NULL,
+	published BOOL NOT NULL DEFAULT false,
+	author_id UUID NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	UNIQUE INDEX e2e_user_notes_slug_idx (slug ASC),
+	INDEX e2e_user_notes_user_id_idx (author_id ASC),
+	FAMILY "primary" (id, content, slug, published, author_id)
+);
+
+CREATE TABLE schema_migration (
+	version VARCHAR(14) NOT NULL,
+	UNIQUE INDEX schema_migration_version_idx (version ASC),
+	FAMILY "primary" (version, rowid)
+);
+
+ALTER TABLE e2e_user_posts ADD CONSTRAINT e2e_user_notes_e2e_users_id_fk FOREIGN KEY (author_id) REFERENCES e2e_authors(id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE e2e_user_posts VALIDATE CONSTRAINT e2e_user_notes_e2e_users_id_fk;

--- a/internal/e2e/fixtures/mysql/down/0.sql
+++ b/internal/e2e/fixtures/mysql/down/0.sql
@@ -2,7 +2,7 @@
 --
 -- Host: 127.0.0.1    Database: pop_test
 -- ------------------------------------------------------
--- Server version	5.7.30
+-- Server version	5.7.31
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -37,4 +37,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-06-20 14:38:23
+-- Dump completed on 2020-08-30 23:11:40

--- a/internal/e2e/fixtures/mysql/down/1.sql
+++ b/internal/e2e/fixtures/mysql/down/1.sql
@@ -53,4 +53,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:25
+-- Dump completed on 2020-08-30 23:11:40

--- a/internal/e2e/fixtures/mysql/down/10.sql
+++ b/internal/e2e/fixtures/mysql/down/10.sql
@@ -71,4 +71,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:23
+-- Dump completed on 2020-08-30 23:11:36

--- a/internal/e2e/fixtures/mysql/down/11.sql
+++ b/internal/e2e/fixtures/mysql/down/11.sql
@@ -1,0 +1,74 @@
+-- MySQL dump 10.13  Distrib 5.7.29, for macos10.14 (x86_64)
+--
+-- Host: 127.0.0.1    Database: pop_test
+-- ------------------------------------------------------
+-- Server version	5.7.31
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `e2e_user_posts`
+--
+
+DROP TABLE IF EXISTS `e2e_user_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_user_posts` (
+  `id` char(36) NOT NULL,
+  `user_id` char(36) NOT NULL,
+  `slug` varchar(32) NOT NULL,
+  `content` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `e2e_user_notes_slug_idx` (`slug`),
+  KEY `e2e_user_notes_user_id_idx` (`user_id`),
+  CONSTRAINT `e2e_user_posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `e2e_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `e2e_users`
+--
+
+DROP TABLE IF EXISTS `e2e_users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_users` (
+  `id` char(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migration`
+--
+
+DROP TABLE IF EXISTS `schema_migration`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migration` (
+  `version` varchar(14) NOT NULL,
+  UNIQUE KEY `schema_migration_version_idx` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2020-08-30 23:11:36

--- a/internal/e2e/fixtures/mysql/down/12.sql
+++ b/internal/e2e/fixtures/mysql/down/12.sql
@@ -1,0 +1,74 @@
+-- MySQL dump 10.13  Distrib 5.7.29, for macos10.14 (x86_64)
+--
+-- Host: 127.0.0.1    Database: pop_test
+-- ------------------------------------------------------
+-- Server version	5.7.31
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `e2e_authors`
+--
+
+DROP TABLE IF EXISTS `e2e_authors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_authors` (
+  `id` char(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `e2e_user_posts`
+--
+
+DROP TABLE IF EXISTS `e2e_user_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_user_posts` (
+  `id` char(36) NOT NULL,
+  `user_id` char(36) NOT NULL,
+  `slug` varchar(32) NOT NULL,
+  `content` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `e2e_user_notes_slug_idx` (`slug`),
+  KEY `e2e_user_notes_user_id_idx` (`user_id`),
+  CONSTRAINT `e2e_user_posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `e2e_authors` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migration`
+--
+
+DROP TABLE IF EXISTS `schema_migration`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migration` (
+  `version` varchar(14) NOT NULL,
+  UNIQUE KEY `schema_migration_version_idx` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2020-08-30 23:11:36

--- a/internal/e2e/fixtures/mysql/down/13.sql
+++ b/internal/e2e/fixtures/mysql/down/13.sql
@@ -1,0 +1,74 @@
+-- MySQL dump 10.13  Distrib 5.7.29, for macos10.14 (x86_64)
+--
+-- Host: 127.0.0.1    Database: pop_test
+-- ------------------------------------------------------
+-- Server version	5.7.31
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `e2e_authors`
+--
+
+DROP TABLE IF EXISTS `e2e_authors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_authors` (
+  `id` char(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `e2e_user_posts`
+--
+
+DROP TABLE IF EXISTS `e2e_user_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_user_posts` (
+  `id` char(36) NOT NULL,
+  `author_id` char(36) NOT NULL,
+  `slug` varchar(32) NOT NULL,
+  `content` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `e2e_user_notes_slug_idx` (`slug`),
+  KEY `e2e_user_notes_user_id_idx` (`author_id`),
+  CONSTRAINT `e2e_user_posts_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `e2e_authors` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migration`
+--
+
+DROP TABLE IF EXISTS `schema_migration`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migration` (
+  `version` varchar(14) NOT NULL,
+  UNIQUE KEY `schema_migration_version_idx` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2020-08-30 23:11:35

--- a/internal/e2e/fixtures/mysql/down/2.sql
+++ b/internal/e2e/fixtures/mysql/down/2.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:25
+-- Dump completed on 2020-08-30 23:11:40

--- a/internal/e2e/fixtures/mysql/down/3.sql
+++ b/internal/e2e/fixtures/mysql/down/3.sql
@@ -70,4 +70,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:25
+-- Dump completed on 2020-08-30 23:11:39

--- a/internal/e2e/fixtures/mysql/down/4.sql
+++ b/internal/e2e/fixtures/mysql/down/4.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:24
+-- Dump completed on 2020-08-30 23:11:39

--- a/internal/e2e/fixtures/mysql/down/5.sql
+++ b/internal/e2e/fixtures/mysql/down/5.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:24
+-- Dump completed on 2020-08-30 23:11:38

--- a/internal/e2e/fixtures/mysql/down/6.sql
+++ b/internal/e2e/fixtures/mysql/down/6.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:24
+-- Dump completed on 2020-08-30 23:11:38

--- a/internal/e2e/fixtures/mysql/down/7.sql
+++ b/internal/e2e/fixtures/mysql/down/7.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:24
+-- Dump completed on 2020-08-30 23:11:38

--- a/internal/e2e/fixtures/mysql/down/8.sql
+++ b/internal/e2e/fixtures/mysql/down/8.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:24
+-- Dump completed on 2020-08-30 23:11:37

--- a/internal/e2e/fixtures/mysql/down/9.sql
+++ b/internal/e2e/fixtures/mysql/down/9.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:23
+-- Dump completed on 2020-08-30 23:11:37

--- a/internal/e2e/fixtures/mysql/up/0.sql
+++ b/internal/e2e/fixtures/mysql/up/0.sql
@@ -53,4 +53,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:21
+-- Dump completed on 2020-08-30 23:11:29

--- a/internal/e2e/fixtures/mysql/up/1.sql
+++ b/internal/e2e/fixtures/mysql/up/1.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:21
+-- Dump completed on 2020-08-30 23:11:30

--- a/internal/e2e/fixtures/mysql/up/10.sql
+++ b/internal/e2e/fixtures/mysql/up/10.sql
@@ -71,4 +71,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:23
+-- Dump completed on 2020-08-30 23:11:34

--- a/internal/e2e/fixtures/mysql/up/11.sql
+++ b/internal/e2e/fixtures/mysql/up/11.sql
@@ -1,0 +1,74 @@
+-- MySQL dump 10.13  Distrib 5.7.29, for macos10.14 (x86_64)
+--
+-- Host: 127.0.0.1    Database: pop_test
+-- ------------------------------------------------------
+-- Server version	5.7.31
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `e2e_authors`
+--
+
+DROP TABLE IF EXISTS `e2e_authors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_authors` (
+  `id` char(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `e2e_user_posts`
+--
+
+DROP TABLE IF EXISTS `e2e_user_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_user_posts` (
+  `id` char(36) NOT NULL,
+  `user_id` char(36) NOT NULL,
+  `slug` varchar(32) NOT NULL,
+  `content` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `e2e_user_notes_slug_idx` (`slug`),
+  KEY `e2e_user_notes_user_id_idx` (`user_id`),
+  CONSTRAINT `e2e_user_posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `e2e_authors` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migration`
+--
+
+DROP TABLE IF EXISTS `schema_migration`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migration` (
+  `version` varchar(14) NOT NULL,
+  UNIQUE KEY `schema_migration_version_idx` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2020-08-30 23:11:34

--- a/internal/e2e/fixtures/mysql/up/12.sql
+++ b/internal/e2e/fixtures/mysql/up/12.sql
@@ -1,0 +1,74 @@
+-- MySQL dump 10.13  Distrib 5.7.29, for macos10.14 (x86_64)
+--
+-- Host: 127.0.0.1    Database: pop_test
+-- ------------------------------------------------------
+-- Server version	5.7.31
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `e2e_authors`
+--
+
+DROP TABLE IF EXISTS `e2e_authors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_authors` (
+  `id` char(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `e2e_user_posts`
+--
+
+DROP TABLE IF EXISTS `e2e_user_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_user_posts` (
+  `id` char(36) NOT NULL,
+  `author_id` char(36) NOT NULL,
+  `slug` varchar(32) NOT NULL,
+  `content` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `e2e_user_notes_slug_idx` (`slug`),
+  KEY `e2e_user_notes_user_id_idx` (`author_id`),
+  CONSTRAINT `e2e_user_posts_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `e2e_authors` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migration`
+--
+
+DROP TABLE IF EXISTS `schema_migration`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migration` (
+  `version` varchar(14) NOT NULL,
+  UNIQUE KEY `schema_migration_version_idx` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2020-08-30 23:11:35

--- a/internal/e2e/fixtures/mysql/up/13.sql
+++ b/internal/e2e/fixtures/mysql/up/13.sql
@@ -1,0 +1,75 @@
+-- MySQL dump 10.13  Distrib 5.7.29, for macos10.14 (x86_64)
+--
+-- Host: 127.0.0.1    Database: pop_test
+-- ------------------------------------------------------
+-- Server version	5.7.31
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `e2e_authors`
+--
+
+DROP TABLE IF EXISTS `e2e_authors`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_authors` (
+  `id` char(36) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `e2e_user_posts`
+--
+
+DROP TABLE IF EXISTS `e2e_user_posts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `e2e_user_posts` (
+  `id` char(36) NOT NULL,
+  `author_id` char(36) DEFAULT NULL,
+  `slug` varchar(32) NOT NULL,
+  `content` varchar(255) NOT NULL DEFAULT '',
+  `published` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `e2e_user_notes_slug_idx` (`slug`),
+  KEY `e2e_user_notes_user_id_idx` (`author_id`),
+  CONSTRAINT `e2e_user_posts_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `e2e_authors` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `schema_migration`
+--
+
+DROP TABLE IF EXISTS `schema_migration`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_migration` (
+  `version` varchar(14) NOT NULL,
+  UNIQUE KEY `schema_migration_version_idx` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2020-08-30 23:11:35

--- a/internal/e2e/fixtures/mysql/up/2.sql
+++ b/internal/e2e/fixtures/mysql/up/2.sql
@@ -70,4 +70,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:22
+-- Dump completed on 2020-08-30 23:11:31

--- a/internal/e2e/fixtures/mysql/up/3.sql
+++ b/internal/e2e/fixtures/mysql/up/3.sql
@@ -71,4 +71,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:22
+-- Dump completed on 2020-08-30 23:11:31

--- a/internal/e2e/fixtures/mysql/up/4.sql
+++ b/internal/e2e/fixtures/mysql/up/4.sql
@@ -71,4 +71,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:22
+-- Dump completed on 2020-08-30 23:11:32

--- a/internal/e2e/fixtures/mysql/up/5.sql
+++ b/internal/e2e/fixtures/mysql/up/5.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:22
+-- Dump completed on 2020-08-30 23:11:32

--- a/internal/e2e/fixtures/mysql/up/6.sql
+++ b/internal/e2e/fixtures/mysql/up/6.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:22
+-- Dump completed on 2020-08-30 23:11:33

--- a/internal/e2e/fixtures/mysql/up/7.sql
+++ b/internal/e2e/fixtures/mysql/up/7.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:22
+-- Dump completed on 2020-08-30 23:11:33

--- a/internal/e2e/fixtures/mysql/up/8.sql
+++ b/internal/e2e/fixtures/mysql/up/8.sql
@@ -72,4 +72,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:23
+-- Dump completed on 2020-08-30 23:11:33

--- a/internal/e2e/fixtures/mysql/up/9.sql
+++ b/internal/e2e/fixtures/mysql/up/9.sql
@@ -71,4 +71,4 @@ CREATE TABLE `schema_migration` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-08-27 23:39:23
+-- Dump completed on 2020-08-30 23:11:34

--- a/internal/e2e/fixtures/postgres/down/0.sql
+++ b/internal/e2e/fixtures/postgres/down/0.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/down/11.sql
+++ b/internal/e2e/fixtures/postgres/down/11.sql
@@ -1,0 +1,107 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+--
+-- Name: e2e_user_posts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_user_posts (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    slug character varying(32) NOT NULL,
+    content character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+ALTER TABLE public.e2e_user_posts OWNER TO postgres;
+
+--
+-- Name: e2e_users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_users (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.e2e_users OWNER TO postgres;
+
+--
+-- Name: schema_migration; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migration (
+    version character varying(14) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migration OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts e2e_user_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_users e2e_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_users
+    ADD CONSTRAINT e2e_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_user_notes_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX e2e_user_notes_slug_idx ON public.e2e_user_posts USING btree (slug);
+
+
+--
+-- Name: e2e_user_notes_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX e2e_user_notes_user_id_idx ON public.e2e_user_posts USING btree (user_id);
+
+
+--
+-- Name: schema_migration_version_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX schema_migration_version_idx ON public.schema_migration USING btree (version);
+
+
+--
+-- Name: e2e_user_posts e2e_user_notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.e2e_users(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/internal/e2e/fixtures/postgres/down/12.sql
+++ b/internal/e2e/fixtures/postgres/down/12.sql
@@ -1,0 +1,107 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+--
+-- Name: e2e_authors; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_authors (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.e2e_authors OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_user_posts (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    slug character varying(32) NOT NULL,
+    content character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+ALTER TABLE public.e2e_user_posts OWNER TO postgres;
+
+--
+-- Name: schema_migration; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migration (
+    version character varying(14) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migration OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts e2e_user_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_authors e2e_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_authors
+    ADD CONSTRAINT e2e_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_user_notes_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX e2e_user_notes_slug_idx ON public.e2e_user_posts USING btree (slug);
+
+
+--
+-- Name: e2e_user_notes_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX e2e_user_notes_user_id_idx ON public.e2e_user_posts USING btree (user_id);
+
+
+--
+-- Name: schema_migration_version_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX schema_migration_version_idx ON public.schema_migration USING btree (version);
+
+
+--
+-- Name: e2e_user_posts e2e_user_notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.e2e_authors(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/internal/e2e/fixtures/postgres/down/13.sql
+++ b/internal/e2e/fixtures/postgres/down/13.sql
@@ -1,0 +1,107 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+--
+-- Name: e2e_authors; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_authors (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.e2e_authors OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_user_posts (
+    id uuid NOT NULL,
+    author_id uuid NOT NULL,
+    slug character varying(32) NOT NULL,
+    content character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+ALTER TABLE public.e2e_user_posts OWNER TO postgres;
+
+--
+-- Name: schema_migration; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migration (
+    version character varying(14) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migration OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts e2e_user_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_authors e2e_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_authors
+    ADD CONSTRAINT e2e_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_user_notes_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX e2e_user_notes_slug_idx ON public.e2e_user_posts USING btree (slug);
+
+
+--
+-- Name: e2e_user_notes_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX e2e_user_notes_user_id_idx ON public.e2e_user_posts USING btree (author_id);
+
+
+--
+-- Name: schema_migration_version_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX schema_migration_version_idx ON public.schema_migration USING btree (version);
+
+
+--
+-- Name: e2e_user_posts e2e_user_notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_user_id_fkey FOREIGN KEY (author_id) REFERENCES public.e2e_authors(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/internal/e2e/fixtures/postgres/up/0.sql
+++ b/internal/e2e/fixtures/postgres/up/0.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/1.sql
+++ b/internal/e2e/fixtures/postgres/up/1.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/11.sql
+++ b/internal/e2e/fixtures/postgres/up/11.sql
@@ -1,0 +1,107 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+--
+-- Name: e2e_authors; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_authors (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.e2e_authors OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_user_posts (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    slug character varying(32) NOT NULL,
+    content character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+ALTER TABLE public.e2e_user_posts OWNER TO postgres;
+
+--
+-- Name: schema_migration; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migration (
+    version character varying(14) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migration OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts e2e_user_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_authors e2e_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_authors
+    ADD CONSTRAINT e2e_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_user_notes_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX e2e_user_notes_slug_idx ON public.e2e_user_posts USING btree (slug);
+
+
+--
+-- Name: e2e_user_notes_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX e2e_user_notes_user_id_idx ON public.e2e_user_posts USING btree (user_id);
+
+
+--
+-- Name: schema_migration_version_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX schema_migration_version_idx ON public.schema_migration USING btree (version);
+
+
+--
+-- Name: e2e_user_posts e2e_user_notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.e2e_authors(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/internal/e2e/fixtures/postgres/up/12.sql
+++ b/internal/e2e/fixtures/postgres/up/12.sql
@@ -1,0 +1,107 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+--
+-- Name: e2e_authors; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_authors (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.e2e_authors OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_user_posts (
+    id uuid NOT NULL,
+    author_id uuid NOT NULL,
+    slug character varying(32) NOT NULL,
+    content character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+ALTER TABLE public.e2e_user_posts OWNER TO postgres;
+
+--
+-- Name: schema_migration; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migration (
+    version character varying(14) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migration OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts e2e_user_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_authors e2e_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_authors
+    ADD CONSTRAINT e2e_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_user_notes_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX e2e_user_notes_slug_idx ON public.e2e_user_posts USING btree (slug);
+
+
+--
+-- Name: e2e_user_notes_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX e2e_user_notes_user_id_idx ON public.e2e_user_posts USING btree (author_id);
+
+
+--
+-- Name: schema_migration_version_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX schema_migration_version_idx ON public.schema_migration USING btree (version);
+
+
+--
+-- Name: e2e_user_posts e2e_user_notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_user_id_fkey FOREIGN KEY (author_id) REFERENCES public.e2e_authors(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/internal/e2e/fixtures/postgres/up/13.sql
+++ b/internal/e2e/fixtures/postgres/up/13.sql
@@ -1,0 +1,108 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+--
+-- Name: e2e_authors; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_authors (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.e2e_authors OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.e2e_user_posts (
+    id uuid NOT NULL,
+    author_id uuid,
+    slug character varying(32) NOT NULL,
+    content character varying(255) DEFAULT ''::character varying NOT NULL,
+    published boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.e2e_user_posts OWNER TO postgres;
+
+--
+-- Name: schema_migration; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migration (
+    version character varying(14) NOT NULL
+);
+
+
+ALTER TABLE public.schema_migration OWNER TO postgres;
+
+--
+-- Name: e2e_user_posts e2e_user_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_authors e2e_users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_authors
+    ADD CONSTRAINT e2e_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: e2e_user_notes_slug_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX e2e_user_notes_slug_idx ON public.e2e_user_posts USING btree (slug);
+
+
+--
+-- Name: e2e_user_notes_user_id_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX e2e_user_notes_user_id_idx ON public.e2e_user_posts USING btree (author_id);
+
+
+--
+-- Name: schema_migration_version_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX schema_migration_version_idx ON public.schema_migration USING btree (version);
+
+
+--
+-- Name: e2e_user_posts e2e_user_notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.e2e_user_posts
+    ADD CONSTRAINT e2e_user_notes_user_id_fkey FOREIGN KEY (author_id) REFERENCES public.e2e_authors(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/internal/e2e/fixtures/postgres/up/2.sql
+++ b/internal/e2e/fixtures/postgres/up/2.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/3.sql
+++ b/internal/e2e/fixtures/postgres/up/3.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/4.sql
+++ b/internal/e2e/fixtures/postgres/up/4.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/5.sql
+++ b/internal/e2e/fixtures/postgres/up/5.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/6.sql
+++ b/internal/e2e/fixtures/postgres/up/6.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/7.sql
+++ b/internal/e2e/fixtures/postgres/up/7.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/postgres/up/8.sql
+++ b/internal/e2e/fixtures/postgres/up/8.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.18
--- Dumped by pg_dump version 12.3
+-- Dumped from database version 9.6.19
+-- Dumped by pg_dump version 12.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/internal/e2e/fixtures/sqlite3/down/11.sql
+++ b/internal/e2e/fixtures/sqlite3/down/11.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "schema_migration" (
+"version" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "schema_migration_version_idx" ON "schema_migration" (version);
+CREATE TABLE IF NOT EXISTS "e2e_users" (
+"id" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "e2e_user_posts" (
+"id" TEXT PRIMARY KEY,
+"user_id" char(36) NOT NULL,
+"slug" TEXT NOT NULL,
+"content" TEXT NOT NULL DEFAULT '',
+FOREIGN KEY ("user_id") REFERENCES "e2e_users" (id) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+CREATE INDEX "e2e_user_notes_user_id_idx" ON "e2e_user_posts" ("user_id");
+CREATE UNIQUE INDEX "e2e_user_notes_slug_idx" ON "e2e_user_posts" (slug);

--- a/internal/e2e/fixtures/sqlite3/down/12.sql
+++ b/internal/e2e/fixtures/sqlite3/down/12.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "schema_migration" (
+"version" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "schema_migration_version_idx" ON "schema_migration" (version);
+CREATE TABLE IF NOT EXISTS "e2e_authors" (
+"id" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "e2e_user_posts" (
+"id" TEXT PRIMARY KEY,
+"user_id" char(36) NOT NULL,
+"slug" TEXT NOT NULL,
+"content" TEXT NOT NULL DEFAULT '',
+FOREIGN KEY ("user_id") REFERENCES e2e_authors (id) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+CREATE INDEX "e2e_user_notes_user_id_idx" ON "e2e_user_posts" ("user_id");
+CREATE UNIQUE INDEX "e2e_user_notes_slug_idx" ON "e2e_user_posts" (slug);

--- a/internal/e2e/fixtures/sqlite3/down/13.sql
+++ b/internal/e2e/fixtures/sqlite3/down/13.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "schema_migration" (
+"version" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "schema_migration_version_idx" ON "schema_migration" (version);
+CREATE TABLE IF NOT EXISTS "e2e_authors" (
+"id" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "e2e_user_posts" (
+"id" TEXT PRIMARY KEY,
+"author_id" char(36) NOT NULL,
+"slug" TEXT NOT NULL,
+"content" TEXT NOT NULL DEFAULT '',
+FOREIGN KEY (author_id) REFERENCES e2e_authors (id) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+CREATE INDEX "e2e_user_notes_user_id_idx" ON "e2e_user_posts" (author_id);
+CREATE UNIQUE INDEX "e2e_user_notes_slug_idx" ON "e2e_user_posts" (slug);

--- a/internal/e2e/fixtures/sqlite3/up/11.sql
+++ b/internal/e2e/fixtures/sqlite3/up/11.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "schema_migration" (
+"version" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "schema_migration_version_idx" ON "schema_migration" (version);
+CREATE TABLE IF NOT EXISTS "e2e_authors" (
+"id" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "e2e_user_posts" (
+"id" TEXT PRIMARY KEY,
+"user_id" char(36) NOT NULL,
+"slug" TEXT NOT NULL,
+"content" TEXT NOT NULL DEFAULT '',
+FOREIGN KEY (user_id) REFERENCES "e2e_authors" (id) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+CREATE INDEX "e2e_user_notes_user_id_idx" ON "e2e_user_posts" (user_id);
+CREATE UNIQUE INDEX "e2e_user_notes_slug_idx" ON "e2e_user_posts" (slug);

--- a/internal/e2e/fixtures/sqlite3/up/12.sql
+++ b/internal/e2e/fixtures/sqlite3/up/12.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "schema_migration" (
+"version" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "schema_migration_version_idx" ON "schema_migration" (version);
+CREATE TABLE IF NOT EXISTS "e2e_authors" (
+"id" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "e2e_user_posts" (
+"id" TEXT PRIMARY KEY,
+"author_id" char(36) NOT NULL,
+"slug" TEXT NOT NULL,
+"content" TEXT NOT NULL DEFAULT '',
+FOREIGN KEY ("author_id") REFERENCES "e2e_authors" (id) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+CREATE INDEX "e2e_user_notes_user_id_idx" ON "e2e_user_posts" ("author_id");
+CREATE UNIQUE INDEX "e2e_user_notes_slug_idx" ON "e2e_user_posts" (slug);

--- a/internal/e2e/fixtures/sqlite3/up/13.sql
+++ b/internal/e2e/fixtures/sqlite3/up/13.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "schema_migration" (
+"version" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "schema_migration_version_idx" ON "schema_migration" (version);
+CREATE TABLE IF NOT EXISTS "e2e_authors" (
+"id" TEXT PRIMARY KEY,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "e2e_user_posts" (
+"id" TEXT PRIMARY KEY,
+"author_id" char(36),
+"slug" TEXT NOT NULL,
+"content" TEXT NOT NULL DEFAULT '',
+"published" bool NOT NULL DEFAULT FALSE,
+FOREIGN KEY (author_id) REFERENCES e2e_authors (id) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX "e2e_user_notes_slug_idx" ON "e2e_user_posts" (slug);
+CREATE INDEX "e2e_user_notes_user_id_idx" ON "e2e_user_posts" (author_id);

--- a/internal/e2e/migrations/20191100000012_rename_user.down.fizz
+++ b/internal/e2e/migrations/20191100000012_rename_user.down.fizz
@@ -1,0 +1,1 @@
+rename_table("e2e_authors", "e2e_users")

--- a/internal/e2e/migrations/20191100000012_rename_user.up.fizz
+++ b/internal/e2e/migrations/20191100000012_rename_user.up.fizz
@@ -1,0 +1,1 @@
+rename_table("e2e_users", "e2e_authors")

--- a/internal/e2e/migrations/20191100000013_rename_user_notes_user.down.fizz
+++ b/internal/e2e/migrations/20191100000013_rename_user_notes_user.down.fizz
@@ -1,0 +1,1 @@
+rename_column("e2e_user_posts", "author_id", "user_id")

--- a/internal/e2e/migrations/20191100000013_rename_user_notes_user.up.fizz
+++ b/internal/e2e/migrations/20191100000013_rename_user_notes_user.up.fizz
@@ -1,0 +1,1 @@
+rename_column("e2e_user_posts", "user_id", "author_id")

--- a/internal/e2e/migrations/20191100000014_rename_user_add_published.down.fizz
+++ b/internal/e2e/migrations/20191100000014_rename_user_add_published.down.fizz
@@ -1,0 +1,2 @@
+drop_column("e2e_user_posts", "published")
+change_column("e2e_user_posts", "author_id", "uuid")

--- a/internal/e2e/migrations/20191100000014_rename_user_add_published.up.fizz
+++ b/internal/e2e/migrations/20191100000014_rename_user_add_published.up.fizz
@@ -1,2 +1,2 @@
-add_column("e2e_user_posts", "published", "bool", {"default": "FALSE"})
+add_column("e2e_user_posts", "published", "bool", {"default_raw": "FALSE"})
 change_column("e2e_user_posts", "author_id", "uuid", {"null": true})

--- a/internal/e2e/migrations/20191100000014_rename_user_add_published.up.fizz
+++ b/internal/e2e/migrations/20191100000014_rename_user_add_published.up.fizz
@@ -1,0 +1,2 @@
+add_column("e2e_user_posts", "published", "bool", {"default": "FALSE"})
+change_column("e2e_user_posts", "author_id", "uuid", {"null": true})

--- a/internal/e2e/migrator_test.go
+++ b/internal/e2e/migrator_test.go
@@ -39,10 +39,12 @@ func run(s *suite.Suite, c *pop.Connection, checkSchema func()) {
 			r.NoError(m.DumpMigrationSchema())
 			expectedFilePath := filepath.Join("fixtures", c.Dialect.Name(), "up", fmt.Sprintf("%d.sql", k))
 
-			if !expectEqualFiles(s, expectedFilePath, actualFilePath) && refreshFixtures {
+			if refreshFixtures {
 				content, err := ioutil.ReadFile(actualFilePath)
 				r.NoError(err)
 				r.NoError(ioutil.WriteFile(expectedFilePath, content, 0666))
+			} else {
+				_ = expectEqualFiles(s, expectedFilePath, actualFilePath)
 			}
 		}
 	})
@@ -57,10 +59,12 @@ func run(s *suite.Suite, c *pop.Connection, checkSchema func()) {
 			r.NoError(m.DumpMigrationSchema())
 			expectedFilePath := filepath.Join("fixtures", c.Dialect.Name(), "down", fmt.Sprintf("%d.sql", k))
 
-			if !expectEqualFiles(s, expectedFilePath, actualFilePath) && refreshFixtures {
+			if refreshFixtures {
 				content, err := ioutil.ReadFile(actualFilePath)
 				r.NoError(err)
 				r.NoError(ioutil.WriteFile(expectedFilePath, content, 0666))
+			} else {
+				_ = expectEqualFiles(s, expectedFilePath, actualFilePath)
 			}
 		}
 	})

--- a/internal/e2e/migrator_test.go
+++ b/internal/e2e/migrator_test.go
@@ -121,7 +121,7 @@ func runTestData(s *suite.Suite, c *pop.Connection, supportsUUID bool) func() {
 		r := s.Require()
 
 		if supportsUUID {
-			r.Error(c.RawQuery("INSERT INTO e2e_users (id, created_at, updated_at) VALUES (?, ?, ?)", "78dba9f7-dd20a39f64cb", time.Now(), time.Now()).Exec(), "should fail because uuid format is not correct")
+			r.Error(c.RawQuery("INSERT INTO e2e_authors (id, created_at, updated_at) VALUES (?, ?, ?)", "78dba9f7-dd20a39f64cb", time.Now(), time.Now()).Exec(), "should fail because uuid format is not correct")
 		}
 
 		runInsertUUID(c, r)
@@ -132,22 +132,22 @@ func runTestData(s *suite.Suite, c *pop.Connection, supportsUUID bool) func() {
 }
 
 func runInsertUUID(c *pop.Connection, r *require.Assertions) {
-	r.NoError(c.RawQuery("INSERT INTO e2e_users (id, created_at, updated_at) VALUES (?, ?, ?)", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", time.Now(), time.Now()).Exec())
-	r.Error(c.RawQuery("INSERT INTO e2e_users (id, created_at, updated_at) VALUES (?, ?, ?)", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", time.Now(), time.Now()).Exec(), "should fail because it is a duplicate primary key")
+	r.NoError(c.RawQuery("INSERT INTO e2e_authors (id, created_at, updated_at) VALUES (?, ?, ?)", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", time.Now(), time.Now()).Exec())
+	r.Error(c.RawQuery("INSERT INTO e2e_authors (id, created_at, updated_at) VALUES (?, ?, ?)", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", time.Now(), time.Now()).Exec(), "should fail because it is a duplicate primary key")
 }
 
 func runForeignKeyChecks(c *pop.Connection, r *require.Assertions) {
-	err := c.RawQuery("INSERT INTO e2e_user_posts (id, user_id, slug) VALUES (?,?,?)", "acd6abe3-38fa-4c3c-a676-933e1b06fa42", "cc1debdc-5d5a-41f3-a36b-48b1f3a03089", "slug-1").Exec()
+	err := c.RawQuery("INSERT INTO e2e_user_posts (id, author_id, slug, published) VALUES (?,?,?, false)", "acd6abe3-38fa-4c3c-a676-933e1b06fa42", "cc1debdc-5d5a-41f3-a36b-48b1f3a03089", "slug-1").Exec()
 	r.Error(err, "should fail because foreign key constraint fails")
 	r.Contains(strings.ToLower(err.Error()), "foreign")
 
-	r.NoError(c.RawQuery("INSERT INTO e2e_user_posts (id, user_id, slug) VALUES (?,?,?)", "03c6c800-54c6-40cd-89f1-7dff731f9b54", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", "slug-1").Exec())
+	r.NoError(c.RawQuery("INSERT INTO e2e_user_posts (id, author_id, slug, published) VALUES (?,?,?, false)", "03c6c800-54c6-40cd-89f1-7dff731f9b54", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", "slug-1").Exec())
 }
 
 func runUniqueKeyChecks(c *pop.Connection, r *require.Assertions) {
-	r.NoError(c.RawQuery("INSERT INTO e2e_user_posts (id, user_id, slug) VALUES (?,?,?)", "ccbf7278-092d-4c6f-a627-84cf45233c6a", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", "dupe-slug").Exec())
+	r.NoError(c.RawQuery("INSERT INTO e2e_user_posts (id, author_id, slug) VALUES (?,?,?)", "ccbf7278-092d-4c6f-a627-84cf45233c6a", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", "dupe-slug").Exec())
 
-	err := c.RawQuery("INSERT INTO e2e_user_posts (id, user_id, slug) VALUES (?,?,?)", "ff7eb268-1640-48d3-b295-57d9a20faf3f", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", "dupe-slug").Exec()
+	err := c.RawQuery("INSERT INTO e2e_user_posts (id, author_id, slug) VALUES (?,?,?)", "ff7eb268-1640-48d3-b295-57d9a20faf3f", "78dba9f7-81af-415e-aa2b-dd20a39f64cb", "dupe-slug").Exec()
 	r.Error(err, "should fail because UNIQUE constraint fails")
 
 	message := strings.ToLower(err.Error())
@@ -157,7 +157,7 @@ func runUniqueKeyChecks(c *pop.Connection, r *require.Assertions) {
 }
 
 func runNotNullChecks(c *pop.Connection, r *require.Assertions) {
-	err := c.RawQuery("INSERT INTO e2e_user_posts (id, user_id) VALUES (?,?)", "a23e6e72-08f9-412f-afb8-01f6af234eb9", "78dba9f7-81af-415e-aa2b-dd20a39f64cb").Exec()
+	err := c.RawQuery("INSERT INTO e2e_user_posts (id, author_id) VALUES (?,?)", "a23e6e72-08f9-412f-afb8-01f6af234eb9", "78dba9f7-81af-415e-aa2b-dd20a39f64cb").Exec()
 	r.Error(err, "should fail because NOT NULL fails")
 	message := strings.ToLower(err.Error())
 	r.True(


### PR DESCRIPTION
This patch resolves issues where CockroachDB would fail to respect foreign keys for changes such as `change_column` because the meta schema did not collect foreign keys appropriately.