### PR TITLE
go get -u to avoid error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,15 @@ go 1.12
 require (
 	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/gobuffalo/flect v0.2.2 // indirect
 	github.com/gobuffalo/plush/v4 v4.0.0
 	github.com/gobuffalo/pop/v5 v5.2.0
+	github.com/gobuffalo/validate/v3 v3.3.0 // indirect
+	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/jackc/pgx/v4 v4.6.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/microcosm-cc/bluemonday v1.0.4 // indirect
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 // indirect
-	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/net v0.0.0-20201022231255-08b38378de70 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 )


### PR DESCRIPTION
error golang.org/x/crypto@v0.0.0-20200604202706-70a84ac30bf9: invalid version