### PR TITLE
preparing go1.18 support (package specific workflow)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
         go-version:
           - "1.16.x"
           - "1.17.x"
+          - "1.18.x"
 
     services:
       mysql:
@@ -67,6 +68,7 @@ jobs:
         go-version:
           - "1.16.x"
           - "1.17.x"
+          - "1.18.x"
 
     services:
       postgres:
@@ -120,6 +122,7 @@ jobs:
         go-version:
           - "1.16.x"
           - "1.17.x"
+          - "1.18.x"
 
     steps:
       - uses: actions/checkout@v3
@@ -168,6 +171,7 @@ jobs:
         go-version:
           - "1.16.x"
           - "1.17.x"
+          - "1.18.x"
         os:
           - "macos-latest"
           - "windows-latest"


### PR DESCRIPTION
pop and fizz use complex test workflow so just keep them as is.
(consider database-specific standardization later)