### PR TITLE
Allow bigint columns in sqlite

### DIFF
--- a/translators/sqlite.go
+++ b/translators/sqlite.go
@@ -37,7 +37,7 @@ func (p *SQLite) CreateTable(t fizz.Table) (string, error) {
 	for _, c := range t.Columns {
 		if c.Primary {
 			switch strings.ToLower(c.ColType) {
-			case "integer", "int":
+			case "integer", "int", "bigint":
 				s = fmt.Sprintf("\"%s\" INTEGER PRIMARY KEY AUTOINCREMENT", c.Name)
 			case "string", "text", "uuid":
 				s = fmt.Sprintf("\"%s\" TEXT PRIMARY KEY", c.Name)
@@ -400,7 +400,7 @@ func (p *SQLite) colType(c fizz.Column) string {
 		return "NUMERIC"
 	case "string", "text":
 		return "TEXT"
-	case "int", "integer":
+	case "int", "integer", "bigint":
 		return "INTEGER"
 	case "float":
 		// precision and scale not supported here

--- a/translators/sqlite_test.go
+++ b/translators/sqlite_test.go
@@ -145,6 +145,42 @@ PRIMARY KEY("user_id", "profile_id")
 	r.Equal(ddl, res)
 }
 
+func (p *SQLiteSuite) Test_SQLite_CreateTable_WithBigIntPrimaryKey() {
+	r := p.Require()
+	ddl := `CREATE TABLE "users" (
+"id" INTEGER PRIMARY KEY AUTOINCREMENT,
+"first_name" TEXT NOT NULL,
+"last_name" TEXT NOT NULL,
+"email" TEXT NOT NULL,
+"permissions" TEXT,
+"age" INTEGER DEFAULT '40',
+"raw" BLOB NOT NULL,
+"into" INTEGER NOT NULL,
+"flotante" REAL NOT NULL,
+"json" TEXT NOT NULL,
+"bytes" BLOB NOT NULL,
+"created_at" DATETIME NOT NULL,
+"updated_at" DATETIME NOT NULL
+);`
+
+	res, _ := fizz.AString(`
+	create_table("users") {
+		t.Column("id", "bigint", {"primary": true})
+		t.Column("first_name", "string", {})
+		t.Column("last_name", "string", {})
+		t.Column("email", "string", {"size":20})
+		t.Column("permissions", "text", {"null": true})
+		t.Column("age", "integer", {"null": true, "default": 40})
+		t.Column("raw", "blob", {})
+		t.Column("into", "int", {})
+		t.Column("flotante", "float", {})
+		t.Column("json", "json", {})
+		t.Column("bytes", "[]byte", {})
+	}
+	`, sqt)
+	r.Equal(ddl, res)
+}
+
 func (p *SQLiteSuite) Test_SQLite_DropTable() {
 	r := p.Require()
 
@@ -204,6 +240,17 @@ func (p *SQLiteSuite) Test_SQLite_AddColumn() {
 	schema.schema["users"] = &fizz.Table{}
 
 	res, _ := fizz.AString(`add_column("users", "mycolumn", "string", {"default": "foo", "size": 50})`, sqt)
+
+	r.Equal(ddl, res)
+}
+
+func (p *SQLiteSuite) Test_SQLite_AddBigIntColumn() {
+	r := p.Require()
+
+	ddl := `ALTER TABLE "users" ADD COLUMN "mycolumn" INTEGER NOT NULL;`
+	schema.schema["users"] = &fizz.Table{}
+
+	res, _ := fizz.AString(`add_column("users", "mycolumn", "bigint")`, sqt)
 
 	r.Equal(ddl, res)
 }


### PR DESCRIPTION
### What is being done in this PR?
Currently, having a bigint column in a fizz file causes the migration to fail against sqlite with an error like `could not call create_table function: can not use bigint as a primary key`, but actually sqlite supports 8 bytes integers in its INTEGER type.

From the [Sqlite docs](https://www.sqlite.org/datatype3.html): 
> INTEGER. The value is a signed integer, stored in 0, 1, 2, 3, 4, 6, or 8 bytes depending on the magnitude of the value.

Rails uses sqlite's integer as a subsititue for bigint in its [schema convention](https://guides.rubyonrails.org/v6.0/active_record_basics.html#schema-conventions):
> Primary keys - By default, Active Record will use an integer column named id as the table's primary key (bigint for PostgreSQL and MySQL, integer for SQLite). When using [Active Record Migrations](https://guides.rubyonrails.org/v6.0/active_record_migrations.html) to create your tables, this column will be automatically created.
  

### What are the main choices made to get to this solution?
Rather than raising an error for bigint columns in sqlite, add an integer column, which supports 8 byte integer values.

### List the manual test cases you've covered before sending this PR:
Using the soda CLI that's built with the changes in this PR, I ran a migration that creates a table with a bigint primary key in sqlite and another migration that adds a bigint column to an existing table.